### PR TITLE
Make the prefix parameter optional for the static picker #14

### DIFF
--- a/xwiki-pro-commons-pickers/xwiki-pro-commons-pickers-api/src/main/resources/templates/pickers_macros.vm
+++ b/xwiki-pro-commons-pickers/xwiki-pro-commons-pickers-api/src/main/resources/templates/pickers_macros.vm
@@ -62,7 +62,12 @@
 #macro (staticPickerDisplayOptions $selectedValues)
   #foreach ($options in $parameters.options)
     <option value="$!escapetool.xml($options.value)"#if ($selectedValues.contains($options.value))
-    selected="selected"#end >$!escapetool.xml($services.localization.render("${parameters.prefix}${options.name}"))
+    selected="selected"#end >
+      #if ($parameters.prefix)
+        $!escapetool.xml($services.localization.render("${parameters.prefix}${options.name}"))
+      #else
+        $!escapetool.xml("$options.name")
+      #end
     </option>
   #end
 #end


### PR DESCRIPTION
* Made it so null prefix doesn't translate option names for static picker, but a '' prefix still does